### PR TITLE
Add React memo to fix scrolling issue on rerender

### DIFF
--- a/mobile-app/app/components/Tabs.tsx
+++ b/mobile-app/app/components/Tabs.tsx
@@ -81,7 +81,12 @@ const Tabs = React.memo((props: TabsProps): JSX.Element => {
   }
 
   return (<ScrollableTabs />)
-})
+}, comparisonFn)
+
+function comparisonFn (prevProps: TabsProps, nextProps: TabsProps): boolean {
+  // compare objects by stringify which won't compare functions
+  return JSON.stringify(prevProps.tabSections) === JSON.stringify(nextProps.tabSections)
+}
 
 function TabLabel (props: {tab: TabOption}): JSX.Element {
   return (


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
- This will fix the the scrollable tab when scrolling to the right in mobile
#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1150

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [x] No console errors on web
- [x] Tested on Light mode and Dark mode*
- [x] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
