### PR TITLE
feat(core): return default evm providers url when evm flag is disabled

### DIFF
--- a/mobile-app/App.tsx
+++ b/mobile-app/App.tsx
@@ -93,32 +93,32 @@ export default function App(): JSX.Element | null {
                 api={ServiceProviderPersistence}
                 logger={Logging}
               >
-                <CustomServiceProvider
-                  api={ServiceProviderPersistence}
-                  logger={Logging}
-                >
-                  <WhaleProvider>
-                    <DeFiScanProvider>
-                      <WalletPersistenceProvider
-                        api={{
-                          ...WalletPersistence,
-                          ...WalletAddressIndexPersistence,
-                        }}
-                        logger={Logging}
-                      >
-                        <StoreProvider>
-                          <StatsProvider>
-                            <FeatureFlagProvider>
-                              <ThemeProvider
-                                api={ThemePersistence}
-                                colorScheme={colorScheme}
-                                logger={Logging}
+                <WhaleProvider>
+                  <DeFiScanProvider>
+                    <WalletPersistenceProvider
+                      api={{
+                        ...WalletPersistence,
+                        ...WalletAddressIndexPersistence,
+                      }}
+                      logger={Logging}
+                    >
+                      <StoreProvider>
+                        <StatsProvider>
+                          <FeatureFlagProvider>
+                            <ThemeProvider
+                              api={ThemePersistence}
+                              colorScheme={colorScheme}
+                              logger={Logging}
+                            >
+                              <LanguageProvider
+                                api={LanguagePersistence}
+                                locale={Localization.locale}
                               >
-                                <LanguageProvider
-                                  api={LanguagePersistence}
-                                  locale={Localization.locale}
-                                >
-                                  <DomainProvider api={DomainPersistence}>
+                                <DomainProvider api={DomainPersistence}>
+                                  <CustomServiceProvider
+                                    api={ServiceProviderPersistence}
+                                    logger={Logging}
+                                  >
                                     <DisplayBalancesProvider>
                                       <ConnectionBoundary>
                                         <GestureHandlerRootView
@@ -136,16 +136,16 @@ export default function App(): JSX.Element | null {
                                         </GestureHandlerRootView>
                                       </ConnectionBoundary>
                                     </DisplayBalancesProvider>
-                                  </DomainProvider>
-                                </LanguageProvider>
-                              </ThemeProvider>
-                            </FeatureFlagProvider>
-                          </StatsProvider>
-                        </StoreProvider>
-                      </WalletPersistenceProvider>
-                    </DeFiScanProvider>
-                  </WhaleProvider>
-                </CustomServiceProvider>
+                                  </CustomServiceProvider>
+                                </DomainProvider>
+                              </LanguageProvider>
+                            </ThemeProvider>
+                          </FeatureFlagProvider>
+                        </StatsProvider>
+                      </StoreProvider>
+                    </WalletPersistenceProvider>
+                  </DeFiScanProvider>
+                </WhaleProvider>
               </StoreServiceProvider>
             </NetworkProvider>
           </PrivacyLockContextProvider>

--- a/mobile-app/app/api/wallet/service_provider.ts
+++ b/mobile-app/app/api/wallet/service_provider.ts
@@ -31,17 +31,10 @@ async function get(
   return undefined;
 }
 
-async function remove(
-  type: CustomServiceProviderType = CustomServiceProviderType.DVM,
-): Promise<void> {
-  await SecuredStoreAPI.removeItem(`${KEY}.${type}`);
-}
-
 /**
  * Service Provider persistence layer
  */
 export const ServiceProviderPersistence = {
   get,
   set,
-  remove,
 };

--- a/mobile-app/app/api/wallet/service_provider.ts
+++ b/mobile-app/app/api/wallet/service_provider.ts
@@ -31,10 +31,17 @@ async function get(
   return undefined;
 }
 
+async function remove(
+  type: CustomServiceProviderType = CustomServiceProviderType.DVM,
+): Promise<void> {
+  await SecuredStoreAPI.removeItem(`${KEY}.${type}`);
+}
+
 /**
  * Service Provider persistence layer
  */
 export const ServiceProviderPersistence = {
   get,
   set,
+  remove,
 };

--- a/mobile-app/app/contexts/CustomServiceProvider.tsx
+++ b/mobile-app/app/contexts/CustomServiceProvider.tsx
@@ -24,7 +24,6 @@ interface CustomServiceProviderContextProps {
       url: NonNullable<string>,
       type?: CustomServiceProviderType,
     ) => Promise<void>;
-    remove: (type: CustomServiceProviderType) => Promise<string | undefined>;
   };
   logger: BaseLogger;
 }
@@ -152,40 +151,29 @@ export function CustomServiceProvider(
     [CustomServiceProviderType.ETHRPC]: ethRpcUrl,
   });
 
-  const resetCustomUrls = async (): Promise<void> => {
-    await Promise.all([
-      api.remove(CustomServiceProviderType.EVM),
-      api.remove(CustomServiceProviderType.ETHRPC),
-    ]);
-  };
-
   useEffect(() => {
-    if (!isEvmFeatureEnabled) {
-      resetCustomUrls();
-    }
-  }, [isEvmFeatureEnabled]);
-
-  useEffect(() => {
+    const url = isEvmFeatureEnabled ? evmUrl : defaultEvmUrl;
     setCurrentUrl((prevState) => ({
       ...prevState,
-      [CustomServiceProviderType.EVM]: evmUrl,
+      [CustomServiceProviderType.EVM]: url,
     }));
-  }, [evmUrl]);
+  }, [evmUrl, isEvmFeatureEnabled]);
 
   useEffect(() => {
+    const url = isEvmFeatureEnabled ? ethRpcUrl : defaultEthRpcUrl;
     setCurrentUrl((prevState) => ({
       ...prevState,
-      [CustomServiceProviderType.ETHRPC]: ethRpcUrl,
+      [CustomServiceProviderType.ETHRPC]: url,
     }));
-  }, [ethRpcUrl]);
+  }, [ethRpcUrl, isEvmFeatureEnabled]);
 
   const isCustomEvmUrl = useMemo(
-    () => currentUrl.EVM !== defaultEvmUrl,
-    [currentUrl.EVM, defaultEvmUrl],
+    () => isEvmFeatureEnabled && currentUrl.EVM !== defaultEvmUrl,
+    [currentUrl.EVM, defaultEvmUrl, isEvmFeatureEnabled],
   );
   const isCustomEthRpcUrl = useMemo(
-    () => currentUrl.ETHRPC !== defaultEthRpcUrl,
-    [currentUrl.ETHRPC, defaultEthRpcUrl],
+    () => isEvmFeatureEnabled && currentUrl.ETHRPC !== defaultEthRpcUrl,
+    [currentUrl.ETHRPC, defaultEthRpcUrl, isEvmFeatureEnabled],
   );
 
   const setCustomUrl = async (

--- a/mobile-app/app/contexts/CustomServiceProvider.tsx
+++ b/mobile-app/app/contexts/CustomServiceProvider.tsx
@@ -169,11 +169,11 @@ export function CustomServiceProvider(
 
   const isCustomEvmUrl = useMemo(
     () => currentUrl.EVM !== defaultEvmUrl,
-    [currentUrl.EVM, defaultEvmUrl, isEvmFeatureEnabled],
+    [currentUrl.EVM, defaultEvmUrl],
   );
   const isCustomEthRpcUrl = useMemo(
     () => currentUrl.ETHRPC !== defaultEthRpcUrl,
-    [currentUrl.ETHRPC, defaultEthRpcUrl, isEvmFeatureEnabled],
+    [currentUrl.ETHRPC, defaultEthRpcUrl],
   );
 
   const setCustomUrl = async (

--- a/mobile-app/app/contexts/CustomServiceProvider.tsx
+++ b/mobile-app/app/contexts/CustomServiceProvider.tsx
@@ -168,11 +168,11 @@ export function CustomServiceProvider(
   }, [ethRpcUrl, isEvmFeatureEnabled]);
 
   const isCustomEvmUrl = useMemo(
-    () => isEvmFeatureEnabled && currentUrl.EVM !== defaultEvmUrl,
+    () => currentUrl.EVM !== defaultEvmUrl,
     [currentUrl.EVM, defaultEvmUrl, isEvmFeatureEnabled],
   );
   const isCustomEthRpcUrl = useMemo(
-    () => isEvmFeatureEnabled && currentUrl.ETHRPC !== defaultEthRpcUrl,
+    () => currentUrl.ETHRPC !== defaultEthRpcUrl,
     [currentUrl.ETHRPC, defaultEthRpcUrl, isEvmFeatureEnabled],
   );
 

--- a/shared/translations/languages/de.json
+++ b/shared/translations/languages/de.json
@@ -424,7 +424,9 @@
     "Cancel transaction": "Transaktion abbrechen",
     "By cancelling, you will lose any changes you made for your transaction.": "Wenn du die Transaktion abbrichst, gehen alle Änderungen, die du für deine Transaktion vorgenommen hast, verloren.",
     "View on Scan": "Ansicht auf Scan",
-    "Go back": "Zurück"
+    "Go back": "Zurück",
+    "Service Providers": "Dienstanbieter",
+    "Custom (3rd-party)": "Benutzerdefiniert (\"Drittanbieter\")"
   },
   "screens/AboutScreen": {
     "About": "Über",
@@ -756,7 +758,9 @@
     "Display payback DUSD loan with DUSD collateral": "Rückzahlungen von DUSD-Darlehen mit DUSD-Sicherheiten anzeigen",
     "CFP/DFIP proposal(s)": "CFP/DFIP-Anträge",
     "Allows the submission of CFP/DFIP proposals": "Ermöglicht die Einreichung von CFP/DFIP-Anträgen",
-    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "Nach der Aktivierung kannst du CFP/DFIP-Anträge direkt über den aktiven Account deiner mobilen Lightwallet einreichen. Möchtest du fortfahren?"
+    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "Nach der Aktivierung kannst du CFP/DFIP-Anträge direkt über den aktiven Account deiner mobilen Lightwallet einreichen. Möchtest du fortfahren?",
+    "Light Wallet beta features are in final testing before their official release. Using beta features are encouraged, but caution is advised when using your assets.": "Die Beta-Funktionen der Lightwallet befinden sich in der Endphase der Tests, bevor sie offiziell veröffentlicht werden. Die Nutzung der Beta-Funktionen wird empfohlen, aber bei der Verwendung deiner Aktiva ist Vorsicht geboten.",
+    "Allows to customize the service providers for both DVM and EVM. Proceed with caution.": "Ermöglicht die Anpassung der Dienstanbieter für DVM und EVM. Gehe mit Vorsicht vor."
   },
   "BottomTabNavigator": {
     "Balances": "Guthaben",
@@ -2176,7 +2180,16 @@
     "Go back": "Zurück",
     "GO BACK": "ZURÜCK",
     "Reset": "Zurücksetzen",
-    "Save changes": "Änderungen sichern"
+    "Save changes": "Änderungen sichern",
+    "Custom Service Provider": "Benutzerdefinierte Dienstanbieter",
+    "Reset providers": "Dienstanbieter zurücksetzen",
+    "ENDPOINT URL (DVM)": "ENDPUNKT-URL (DVM)",
+    "Used to get balance from Native DFC (MainNet and TestNet)": "Wird verwendet, um den Native-DFC-Saldo (MainNet und TestNet) abzurufen",
+    "ENDPOINT URL (EVM)": "ENDPUNKT-URL (EVM)",
+    "Used to get balance from EVM (MainNet and TestNet)": "Wird verwendet, um den EVM-Saldo (MainNet und TestNet) abzurufen",
+    "ENDPOINT URL (ETH-RPC)": "ENDPUNKT-URL (ETH-RPC)",
+    "Used to get Nonce and Chain ID": "Wird verwendet, um Nonce und Chain ID abzurufen",
+    "Only add URLs that are fully trusted and secured. Adding malicious service providers may result in irrecoverable funds. Proceed at your own risk.": "Füge nur URLs hinzu, die vollständig vertrauenswürdig und sicher sind. Das Hinzufügen von bösartigen Dienstanbietern kann dazu führen, dass Guthaben unwiederbringlich verloren gehen. Das Vorgehen erfolgt auf eigene Gefahr."
   },
   "components/QuickBid": {
     "QUICK BID": "SCHNELLES GEBOT",

--- a/shared/translations/languages/es.json
+++ b/shared/translations/languages/es.json
@@ -437,7 +437,9 @@
     "Cancel transaction": "Cancel transaction",
     "By cancelling, you will lose any changes you made for your transaction.": "By cancelling, you will lose any changes you made for your transaction.",
     "View on Scan": "View on Scan",
-    "Go back": "Vuelve atrás"
+    "Go back": "Vuelve atrás",
+    "Service Providers": "Service Providers",
+    "Custom (3rd-party)": "Custom (3rd-party)"
   },
   "screens/AboutScreen": {
     "About": "Más información",
@@ -775,7 +777,9 @@
     "Display payback DUSD loan with DUSD collateral": "Mostrar pago de préstamo de DUSD con el DUSD del colateral",
     "CFP/DFIP proposal(s)": "CFP/DFIP proposal(s)",
     "Allows the submission of CFP/DFIP proposals": "Allows the submission of CFP/DFIP proposals",
-    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?"
+    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?",
+    "Light Wallet beta features are in final testing before their official release. Using beta features are encouraged, but caution is advised when using your assets.": "Light Wallet beta features are in final testing before their official release. Using beta features are encouraged, but caution is advised when using your assets.",
+    "Allows to customize the service providers for both DVM and EVM. Proceed with caution.": "Allows to customize the service providers for both DVM and EVM. Proceed with caution."
   },
   "BottomTabNavigator": {
     "Balances": "Saldos",
@@ -2205,7 +2209,16 @@
     "Go back": "Go back",
     "GO BACK": "GO BACK",
     "Reset": "Reset",
-    "Save changes": "Guardar cambios"
+    "Save changes": "Guardar cambios",
+    "Custom Service Provider": "Custom Service Provider",
+    "Reset providers": "Reset providers",
+    "ENDPOINT URL (DVM)": "ENDPOINT URL (DVM)",
+    "Used to get balance from Native DFC (MainNet and TestNet)": "Used to get balance from Native DFC (MainNet and TestNet)",
+    "ENDPOINT URL (EVM)": "ENDPOINT URL (EVM)",
+    "Used to get balance from EVM (MainNet and TestNet)": "Used to get balance from EVM (MainNet and TestNet)",
+    "ENDPOINT URL (ETH-RPC)": "ENDPOINT URL (ETH-RPC)",
+    "Used to get Nonce and Chain ID": "Used to get Nonce and Chain ID",
+    "Only add URLs that are fully trusted and secured. Adding malicious service providers may result in irrecoverable funds. Proceed at your own risk.": "Only add URLs that are fully trusted and secured. Adding malicious service providers may result in irrecoverable funds. Proceed at your own risk."
   },
   "components/QuickBid": {
     "QUICK BID": "OFERTA RAPIDA",

--- a/shared/translations/languages/fr.json
+++ b/shared/translations/languages/fr.json
@@ -434,7 +434,9 @@
     "Cancel transaction": "Annuler la transaction",
     "By cancelling, you will lose any changes you made for your transaction.": "En annulant, vous perdrez toutes les modifications apportées à votre transaction.",
     "View on Scan": "Voir sur Scan",
-    "Go back": "Retour"
+    "Go back": "Retour",
+    "Service Providers": "Fournisseurs de services",
+    "Custom (3rd-party)": "Personnalisé (tierce partie)"
   },
   "screens/AboutScreen": {
     "About": "A propos de l'appli",
@@ -768,7 +770,9 @@
     "Display payback DUSD loan with DUSD collateral": "Afficher le remboursement du prêt DUSD avec garantie DUSD",
     "CFP/DFIP proposal(s)": "Proposition(s) CFP/DFIP",
     "Allows the submission of CFP/DFIP proposals": "Permet la soumission de propositions CFP/DFIP",
-    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "Dès l'activation, vous pourrez soumettre des propositions CFP/DFIP directement en utilisant votre compte actif du portefeuille léger mobile. Continuer ?"
+    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "Dès l'activation, vous pourrez soumettre des propositions CFP/DFIP directement en utilisant votre compte actif du portefeuille léger mobile. Continuer ?",
+    "Light Wallet beta features are in final testing before their official release. Using beta features are encouraged, but caution is advised when using your assets.": "Les fonctions bêta du portefeuille léger sont en phase de test final avant leur lancement officiel. L'utilisation des fonctionnalités bêta est encouragée, mais la prudence est de mise lors de l'utilisation de vos actifs.",
+    "Allows to customize the service providers for both DVM and EVM. Proceed with caution.": "Permet de personnaliser les fournisseurs de services pour DVM et EVM. Procéder avec prudence."
   },
   "BottomTabNavigator": {
     "Balances": "Soldes",
@@ -2186,7 +2190,16 @@
     "Go back": "Retour",
     "GO BACK": "RETOUR",
     "Reset": "Réinitialiser",
-    "Save changes": "Sauvegarder les modifications"
+    "Save changes": "Sauvegarder les modifications",
+    "Custom Service Provider": "Fournisseur de service personnalisé",
+    "Reset providers": "Réinitialiser les fournisseurs",
+    "ENDPOINT URL (DVM)": "URL DU POINT DE TERMINAISON (DVM)",
+    "Used to get balance from Native DFC (MainNet and TestNet)": "Utilisé pour obtenir le solde de DFC natif (MainNet et TestNet)",
+    "ENDPOINT URL (EVM)": "URL DU POINT DE TERMINAISON (EVM)",
+    "Used to get balance from EVM (MainNet and TestNet)": "Utilisé pour obtenir le solde de l'EVM (MainNet et TestNet)",
+    "ENDPOINT URL (ETH-RPC)": "URL DU POINT DE TERMINAISON (ETH-RPC)",
+    "Used to get Nonce and Chain ID": "Utilisé pour obtenir le Nonce et le Chain ID",
+    "Only add URLs that are fully trusted and secured. Adding malicious service providers may result in irrecoverable funds. Proceed at your own risk.": "N'ajoutez que des URL entièrement fiables et sécurisées. L'ajout de fournisseurs de services malveillants peut entraîner la perte de fonds. Procédez à vos risques et périls."
   },
   "components/QuickBid": {
     "QUICK BID": "ENCHÈRE RAPIDE",

--- a/shared/translations/languages/it.json
+++ b/shared/translations/languages/it.json
@@ -438,7 +438,9 @@
     "Cancel transaction": "Cancel transaction",
     "By cancelling, you will lose any changes you made for your transaction.": "By cancelling, you will lose any changes you made for your transaction.",
     "View on Scan": "View on Scan",
-    "Go back": "Torna indietro"
+    "Go back": "Torna indietro",
+    "Service Providers": "Service Providers",
+    "Custom (3rd-party)": "Custom (3rd-party)"
   },
   "screens/AboutScreen": {
     "About": "Informazioni su",
@@ -774,7 +776,9 @@
     "Display payback DUSD loan with DUSD collateral": "Display payback DUSD loan with DUSD collateral",
     "CFP/DFIP proposal(s)": "CFP/DFIP proposal(s)",
     "Allows the submission of CFP/DFIP proposals": "Allows the submission of CFP/DFIP proposals",
-    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?"
+    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?",
+    "Light Wallet beta features are in final testing before their official release. Using beta features are encouraged, but caution is advised when using your assets.": "Light Wallet beta features are in final testing before their official release. Using beta features are encouraged, but caution is advised when using your assets.",
+    "Allows to customize the service providers for both DVM and EVM. Proceed with caution.": "Allows to customize the service providers for both DVM and EVM. Proceed with caution."
   },
   "BottomTabNavigator": {
     "Balances": "Saldi",
@@ -2200,8 +2204,16 @@
     "Go back": "Go back",
     "GO BACK": "GO BACK",
     "Reset": "Reset",
-    "Save changes": "Salva modifiche"
-
+    "Save changes": "Salva modifiche",
+    "Custom Service Provider": "Custom Service Provider",
+    "Reset providers": "Reset providers",
+    "ENDPOINT URL (DVM)": "ENDPOINT URL (DVM)",
+    "Used to get balance from Native DFC (MainNet and TestNet)": "Used to get balance from Native DFC (MainNet and TestNet)",
+    "ENDPOINT URL (EVM)": "ENDPOINT URL (EVM)",
+    "Used to get balance from EVM (MainNet and TestNet)": "Used to get balance from EVM (MainNet and TestNet)",
+    "ENDPOINT URL (ETH-RPC)": "ENDPOINT URL (ETH-RPC)",
+    "Used to get Nonce and Chain ID": "Used to get Nonce and Chain ID",
+    "Only add URLs that are fully trusted and secured. Adding malicious service providers may result in irrecoverable funds. Proceed at your own risk.": "Only add URLs that are fully trusted and secured. Adding malicious service providers may result in irrecoverable funds. Proceed at your own risk."
   },
   "components/QuickBid": {
     "QUICK BID": "OFFERTA RAPIDA",

--- a/shared/translations/languages/zh-Hans.json
+++ b/shared/translations/languages/zh-Hans.json
@@ -425,7 +425,9 @@
     "Cancel transaction": "Cancel transaction",
     "By cancelling, you will lose any changes you made for your transaction.": "By cancelling, you will lose any changes you made for your transaction.",
     "View on Scan": "往 DeFi Scan 查看",
-    "Go back": "回到上一页"
+    "Go back": "回到上一页",
+    "Service Providers": "服务提供商",
+    "Custom (3rd-party)": "自定义（第三方"
   },
   "screens/AboutScreen": {
     "About": "关于",
@@ -758,7 +760,9 @@
     "Display payback DUSD loan with DUSD collateral": "Display payback DUSD loan with DUSD collateral",
     "CFP/DFIP proposal(s)": "CFP/DFIP 提案",
     "Allows the submission of CFP/DFIP proposals": "允许提交 CFP/DFIP 提案",
-    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "激活后，您将能够使用您活跃的移动端Light Wallet账户直接提交 CFP/DFIP 提案。 你要继续吗？"
+    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "激活后，您将能够使用您活跃的移动端Light Wallet账户直接提交 CFP/DFIP 提案。 你要继续吗？",
+    "Light Wallet beta features are in final testing before their official release. Using beta features are encouraged, but caution is advised when using your assets.": "Light Wallet beta 功能目前在正式发布前进行最终测试。 我们鼓励使用测试版功能，但建议您在使用资产时务必小心。",
+    "Allows to customize the service providers for both DVM and EVM. Proceed with caution.": "允许为 DVM 和 EVM 自定义服务提供者。 谨慎行事。"
   },
   "BottomTabNavigator": {
     "Balances": "总资金",
@@ -2182,7 +2186,16 @@
     "Go back": "Go back",
     "GO BACK": "GO BACK",
     "Reset": "Reset",
-    "Save changes": "储存修改"
+    "Save changes": "储存修改",
+    "Custom Service Provider": "自定义服务提供商",
+    "Reset providers": "Reset 提供商",
+    "ENDPOINT URL (DVM)": "端点 URL (DVM)",
+    "Used to get balance from Native DFC (MainNet and TestNet)": "用于从原生DFC（主网和测试网）获取余额",
+    "ENDPOINT URL (EVM)": "端点 URL (EVM)",
+    "Used to get balance from EVM (MainNet and TestNet)": "用于从EVM（主网和测试网）获取余额",
+    "ENDPOINT URL (ETH-RPC)": "端点 URL (ETH-RPC)",
+    "Used to get Nonce and Chain ID": "用于获取Nonce和Chain ID",
+    "Only add URLs that are fully trusted and secured. Adding malicious service providers may result in irrecoverable funds. Proceed at your own risk.": "仅添加完全受信任且安全的 URL。 添加恶意服务提供商可能会导致资金无法收回。 继续行动则需要您自担风险。"
   },
   "components/QuickBid": {
     "QUICK BID": "快速标价",

--- a/shared/translations/languages/zh-Hant.json
+++ b/shared/translations/languages/zh-Hant.json
@@ -425,7 +425,9 @@
     "Cancel transaction": "Cancel transaction",
     "By cancelling, you will lose any changes you made for your transaction.": "By cancelling, you will lose any changes you made for your transaction.",
     "View on Scan": "往 DeFi Scan 查看",
-    "Go back": "回到上一頁"
+    "Go back": "回到上一頁",
+    "Service Providers": "服務提供者",
+    "Custom (3rd-party)": "自定義（第三方）"
   },
   "screens/AboutScreen": {
     "About": "關於",
@@ -758,7 +760,9 @@
     "Display payback DUSD loan with DUSD collateral": "Display payback DUSD loan with DUSD collateral",
     "CFP/DFIP proposal(s)": "CFP/DFIP 提案",
     "Allows the submission of CFP/DFIP proposals": "允許提交 CFP/DFIP 提案",
-    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "激活後，您將能夠使用您活躍的移動端Light Wallet賬戶直接提交 CFP/DFIP 提案。你要繼續嗎？"
+    "Upon activation, you will be able to submit CFP/DFIP proposals directly using your active mobile Light Wallet account. Do you want to continue?": "激活後，您將能夠使用您活躍的移動端Light Wallet賬戶直接提交 CFP/DFIP 提案。你要繼續嗎？",
+    "Light Wallet beta features are in final testing before their official release. Using beta features are encouraged, but caution is advised when using your assets.": "Light Wallet beta 功能目前在正式發布前進行最終測試。 我們鼓勵使用測試版功能，但建議您在使用資產時務必小心。",
+    "Allows to customize the service providers for both DVM and EVM. Proceed with caution.": "允許為 DVM 和 EVM 自訂服務提供者。 謹慎行事。"
   },
   "BottomTabNavigator": {
     "Balances": "總資金",
@@ -2183,7 +2187,16 @@
     "Go back": "Go back",
     "GO BACK": "GO BACK",
     "Reset": "Reset",
-    "Save changes": "儲存修改"
+    "Save changes": "儲存修改",
+    "Custom Service Provider": "自定義服務供應商",
+    "Reset providers": "Reset 供應商",
+    "ENDPOINT URL (DVM)": "端點 URL (DVM)",
+    "Used to get balance from Native DFC (MainNet and TestNet)": "用於從原生DFC（主網和測試網）取得餘額",
+    "ENDPOINT URL (EVM)": "端點 URL (EVM)",
+    "Used to get balance from EVM (MainNet and TestNet)": "用於從EVM（主網和測試網）取得餘額",
+    "ENDPOINT URL (ETH-RPC)": "端點 URL (ETH-RPC)",
+    "Used to get Nonce and Chain ID": "用於取得Nonce和Chain ID",
+    "Only add URLs that are fully trusted and secured. Adding malicious service providers may result in irrecoverable funds. Proceed at your own risk.": "僅添加完全受信任且安全的 URL。 新增惡意服務提供者可能會導致資金無法收回。 繼續行動則需要您自擔風險。"
   },
   "components/QuickBid": {
     "QUICK BID": "快速標價",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Return default EVM and ETH RPC provider urls when EVM feature flag is disabled
- Add translations for updated Service Provider screen

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
