### PR TITLE
fix(core): skip eth provider for transfer domain

### DIFF
--- a/mobile-app/app/contexts/CustomServiceProvider.tsx
+++ b/mobile-app/app/contexts/CustomServiceProvider.tsx
@@ -102,7 +102,7 @@ function getBlockscoutUrl(network: EnvironmentNetwork) {
   }
 }
 
-function getEthRpcUrl(network: EnvironmentNetwork) {
+export function getEthRpcUrl(network: EnvironmentNetwork) {
   // TODO: Add proper ethereum RPC URLs for each network
   switch (network) {
     case EnvironmentNetwork.LocalPlayground:

--- a/mobile-app/app/screens/AppNavigator/screens/Portfolio/screens/ConvertConfirmationScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Portfolio/screens/ConvertConfirmationScreen.tsx
@@ -33,7 +33,6 @@ import {
 } from "@api/transaction/transfer_domain";
 import { useNetworkContext } from "@waveshq/walletkit-ui";
 import { NetworkName } from "@defichain/jellyfish-network";
-import { useEVMProvider } from "@contexts/EVMProvider";
 import { PortfolioParamList } from "../PortfolioNavigator";
 
 type Props = StackScreenProps<PortfolioParamList, "ConvertConfirmationScreen">;
@@ -49,7 +48,6 @@ export function ConvertConfirmationScreen({ route }: Props): JSX.Element {
   } = route.params;
   const { networkName } = useNetworkContext();
   const { address, evmAddress } = useWalletContext();
-  const { provider, chainId } = useEVMProvider();
   const addressLabel = useAddressLabel(address);
   const hasPendingJob = useSelector((state: RootState) =>
     hasTxQueued(state.transactionQueue),
@@ -122,9 +120,6 @@ export function ConvertConfirmationScreen({ route }: Props): JSX.Element {
         logger,
       );
     } else {
-      const nonce = provider
-        ? await provider.getTransactionCount(evmAddress)
-        : 0;
       await constructSignedTransferDomain(
         {
           amount,
@@ -132,8 +127,6 @@ export function ConvertConfirmationScreen({ route }: Props): JSX.Element {
           sourceToken,
           targetToken,
           networkName,
-          chainId,
-          nonce,
           evmAddress,
           dvmAddress: address,
         },
@@ -355,20 +348,16 @@ async function constructSignedTransferDomain(
     sourceToken,
     targetToken,
     networkName,
-    chainId,
     dvmAddress,
     evmAddress,
-    nonce,
   }: {
     convertDirection: ConvertDirection;
     sourceToken: TransferDomainToken;
     targetToken: TransferDomainToken;
     amount: BigNumber;
     networkName: NetworkName;
-    chainId?: number;
     dvmAddress: string;
     evmAddress: string;
-    nonce: number;
   },
   dispatch: Dispatch<any>,
   onBroadcast: () => void,
@@ -385,10 +374,8 @@ async function constructSignedTransferDomain(
           networkName,
           onBroadcast,
           onConfirmation: () => {},
-          chainId,
           dvmAddress,
           evmAddress,
-          nonce,
         }),
       ),
     );

--- a/mobile-app/app/screens/AppNavigator/screens/Portfolio/screens/SendConfirmationScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Portfolio/screens/SendConfirmationScreen.tsx
@@ -50,7 +50,6 @@ import {
   AddressType as JellyfishAddressType,
 } from "@waveshq/walletkit-core";
 import { DomainType, useDomainContext } from "@contexts/DomainContext";
-import { useEVMProvider } from "@contexts/EVMProvider";
 import { PortfolioParamList } from "../PortfolioNavigator";
 
 type Props = StackScreenProps<PortfolioParamList, "SendConfirmationScreen">;
@@ -81,7 +80,6 @@ export function SendConfirmationScreen({ route }: Props): JSX.Element {
     hasOceanTXQueued(state.ocean),
   );
   const dispatch = useAppDispatch();
-  const { provider, chainId } = useEVMProvider();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const navigation = useNavigation<NavigationProp<PortfolioParamList>>();
   const [isOnPage, setIsOnPage] = useState<boolean>(true);
@@ -101,15 +99,12 @@ export function SendConfirmationScreen({ route }: Props): JSX.Element {
       return;
     }
     setIsSubmitting(true);
-    const nonce = provider ? await provider.getTransactionCount(evmAddress) : 0;
     await send(
       {
         address: destination,
         token,
         amount,
         domain,
-        chainId,
-        nonce,
         networkName: network.networkName,
       },
       dispatch,
@@ -364,13 +359,11 @@ interface SendForm {
   address: string;
   token: WalletToken;
   domain: DomainType;
-  nonce: number;
-  chainId?: number;
   networkName: NetworkName;
 }
 
 async function send(
-  { address, token, amount, domain, networkName, nonce, chainId }: SendForm,
+  { address, token, amount, domain, networkName }: SendForm,
   dispatch: Dispatch<any>,
   onBroadcast: () => void,
   logger: NativeLoggingProps,
@@ -424,8 +417,6 @@ async function send(
               dvmAddress,
               evmAddress,
               networkName,
-              nonce,
-              chainId,
               convertDirection: sendDirection,
             });
           }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Issue with `Invalid nonce` still persists on Android devices, probably because of eth rpc provider not loading properly with context. Reverting to previous version wherein transfer domain function is not dependent on context.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes DFC-364

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
