### PR TITLE
feat(ui-ux): allow dusd only vaults

### DIFF
--- a/mobile-app/app/screens/AppNavigator/screens/Loans/screens/BorrowLoanTokenScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/screens/BorrowLoanTokenScreen.tsx
@@ -62,7 +62,7 @@ import { useMaxLoan } from "../hooks/MaxLoanAmount";
 import { useInterestPerBlock } from "../hooks/InterestPerBlock";
 import { useBlocksPerDay } from "../hooks/BlocksPerDay";
 import { BottomSheetLoanTokensList } from "../components/BottomSheetLoanTokensList";
-import { useDFIRequirementForDusdLoanAndCollateral } from "../hooks/DFIRequirementForDusdLoanAndCollateral";
+import { useRequirementForDusdLoan } from "../hooks/RequirementForDusdLoan";
 import { CollateralizationRatioDisplay } from "../components/CollateralizationRatioDisplay";
 
 type Props = StackScreenProps<LoanParamList, "BorrowLoanTokenScreen">;
@@ -134,19 +134,18 @@ export function BorrowLoanTokenScreen({
     interestPerBlock,
   );
   const [disableContinue, setDisableContinue] = useState(false);
-  const { isDFILessThanHalfOfRequiredCollateral } =
-    useDFIRequirementForDusdLoanAndCollateral({
-      collateralAmounts: vault.collateralAmounts,
-      loanAmounts: vault.loanAmounts,
-      collateralValue: new BigNumber(vault.collateralValue),
-      loanValue: new BigNumber(vault.loanValue).plus(
-        new BigNumber(borrowAmount).isNaN()
-          ? new BigNumber(0)
-          : new BigNumber(borrowAmount),
-      ),
-      loanToken: loanToken,
-      minColRatio: vault.loanScheme.minColRatio,
-    });
+  const { isNotFulfillingRequiredCollateral } = useRequirementForDusdLoan({
+    collateralAmounts: vault.collateralAmounts,
+    loanAmounts: vault.loanAmounts,
+    collateralValue: new BigNumber(vault.collateralValue),
+    loanValue: new BigNumber(vault.loanValue).plus(
+      new BigNumber(borrowAmount).isNaN()
+        ? new BigNumber(0)
+        : new BigNumber(borrowAmount),
+    ),
+    loanToken: loanToken,
+    minColRatio: vault.loanScheme.minColRatio,
+  });
   const { atRiskThreshold } = useColRatioThreshold(
     new BigNumber(vault.loanScheme.minColRatio),
   );
@@ -304,9 +303,10 @@ export function BorrowLoanTokenScreen({
       });
     } else if (resultingColRatio.isLessThan(vault.loanScheme.minColRatio)) {
       setInputValidationMessage(undefined); // this error message is moved to below quick input
-    } else if (isDFILessThanHalfOfRequiredCollateral) {
+    } else if (isNotFulfillingRequiredCollateral) {
       setInputValidationMessage({
-        message: "Insufficient DFI in vault. Add more to borrow DUSD.",
+        message:
+          "Insufficient DFI or not only DUSD in vault. Add more to borrow DUSD.",
         type: ValidationMessageType.Error,
       });
     } else if (
@@ -452,8 +452,8 @@ export function BorrowLoanTokenScreen({
                         ).isGreaterThan(0),
                       hasDFIandDUSDCollateral: () =>
                         requiredTokensShare.isGreaterThan(0), // need >0 DFI and or DUSD to take loan
-                      isDFILessThanHalfOfRequiredCollateral: () =>
-                        !isDFILessThanHalfOfRequiredCollateral, // min 50% DFI as collateral if taking DUSD loan
+                      isNotFulfillingRequiredCollateral: () =>
+                        !isNotFulfillingRequiredCollateral, // min 50% DFI or 100% DUSD as collateral if taking DUSD loan
                     },
                   }}
                 />

--- a/shared/translations/languages/de.json
+++ b/shared/translations/languages/de.json
@@ -1905,7 +1905,7 @@
     "Amount entered will result in vault liquidation": "Der eingegebene Betrag wird zur Liquidation des Vaults führen.",
     "Amount entered may liquidate the vault. Proceed at your own risk.": "Der eingegebene Betrag kann den Vault liquidieren. Das Vorgehen erfolgt auf eigene Gefahr.",
     "Insufficient DFI and/or DUSD in vault. Add more to start minting dTokens.": "Nicht genügend DFI und/oder DUSD im Vault. Füge mehr hinzu, um dToken zu minten.",
-    "Insufficient DFI in vault. Add more to borrow DUSD.": "Unzureichende DFI im Vault. Füge mehr hinzu, um DUSD zu leihen.",
+    "Insufficient DFI or not only DUSD in vault. Add more to borrow DUSD.": "Unzureichende DFI oder nicht nur DUSD im Vault. Füge mehr hinzu, um DUSD zu leihen.",
     "Review full details in the next screen": "Überprüfe alle Details in der nächsten Ansicht",
     "Max loan amount entered": "Maximaler Darlehensbetrag eingegeben",
     "{{percent}} of max loan amount entered": "{{percent}} des max. Darlehensbetrags eingegeben",

--- a/shared/translations/languages/es.json
+++ b/shared/translations/languages/es.json
@@ -1933,7 +1933,7 @@
     "Amount entered will result in vault liquidation": "Amount entered will result in vault liquidation",
     "Amount entered may liquidate the vault. Proceed at your own risk.": "Amount entered may liquidate the vault. Proceed at your own risk.",
     "Insufficient DFI and/or DUSD in vault. Add more to start minting dTokens.": "Insufficient DFI and/or DUSD in vault. Add more to start minting dTokens.",
-    "Insufficient DFI in vault. Add more to borrow DUSD.": "Insufficient DFI in vault. Add more to borrow DUSD.",
+    "Insufficient DFI or not only DUSD in vault. Add more to borrow DUSD.": "Insufficient DFI or not only DUSD in vault. Add more to borrow DUSD.",
     "Review full details in the next screen": "Review full details in the next screen",
     "Max loan amount entered": "Max loan amount entered",
     "{{percent}} of max loan amount entered": "{{percent}} of max loan amount entered",

--- a/shared/translations/languages/fr.json
+++ b/shared/translations/languages/fr.json
@@ -1914,7 +1914,7 @@
     "Amount entered will result in vault liquidation": "Le montant saisi entraînera la liquidation du vault.",
     "Amount entered may liquidate the vault. Proceed at your own risk.": "Le montant donné peut entraîner la liquidation du vault. Procédez à vos propres risques.",
     "Insufficient DFI and/or DUSD in vault. Add more to start minting dTokens.": "Insuffisance de DFI et/ou de DUSD dans le vault. Ajoutez-en plus pour commencer le minting des dTokens.",
-    "Insufficient DFI in vault. Add more to borrow DUSD.": "Insuffisance de DFI dans le vault. Ajoutez-en plus pour emprunter des DUSD.",
+    "Insufficient DFI or not only DUSD in vault. Add more to borrow DUSD.": "Insuffisance de DFI ou pas seulement DUSD dans le vault. Ajoutez-en plus pour emprunter des DUSD.",
     "Review full details in the next screen": "Vérifiez tous les détails dans l'écran suivant",
     "Max loan amount entered": "Montant max. du prêt saisi",
     "{{percent}} of max loan amount entered": "{{percent}} du montant max. du prêt saisi",

--- a/shared/translations/languages/it.json
+++ b/shared/translations/languages/it.json
@@ -1928,7 +1928,7 @@
     "Amount entered will result in vault liquidation": "Amount entered will result in vault liquidation",
     "Amount entered may liquidate the vault. Proceed at your own risk.": "Amount entered may liquidate the vault. Proceed at your own risk.",
     "Insufficient DFI and/or DUSD in vault. Add more to start minting dTokens.": "Insufficient DFI and/or DUSD in vault. Add more to start minting dTokens.",
-    "Insufficient DFI in vault. Add more to borrow DUSD.": "Insufficient DFI in vault. Add more to borrow DUSD.",
+    "Insufficient DFI or not only DUSD in vault. Add more to borrow DUSD.": "Insufficient DFI or not only DUSD in vault. Add more to borrow DUSD.",
     "Review full details in the next screen": "Review full details in the next screen",
     "Max loan amount entered": "Max loan amount entered",
     "{{percent}} of max loan amount entered": "{{percent}} of max loan amount entered",

--- a/shared/translations/languages/zh-Hans.json
+++ b/shared/translations/languages/zh-Hans.json
@@ -1906,7 +1906,7 @@
     "Amount entered will result in vault liquidation": "Amount entered will result in vault liquidation",
     "Amount entered may liquidate the vault. Proceed at your own risk.": "Amount entered may liquidate the vault. Proceed at your own risk.",
     "Insufficient DFI and/or DUSD in vault. Add more to start minting dTokens.": "Insufficient DFI and/or DUSD in vault. Add more to start minting dTokens.",
-    "Insufficient DFI in vault. Add more to borrow DUSD.": "Insufficient DFI in vault. Add more to borrow DUSD.",
+    "Insufficient DFI or not only DUSD in vault. Add more to borrow DUSD.": "Insufficient DFI or not only DUSD in vault. Add more to borrow DUSD.",
     "Review full details in the next screen": "在下一个屏幕中查看完整详细信息",
     "Max loan amount entered": "已输入最高贷款金额",
     "{{percent}} of max loan amount entered": "已输入最高贷款金额的 {{percent}}%",

--- a/shared/translations/languages/zh-Hant.json
+++ b/shared/translations/languages/zh-Hant.json
@@ -1908,7 +1908,7 @@
     "Amount entered will result in vault liquidation": "Amount entered will result in vault liquidation",
     "Amount entered may liquidate the vault. Proceed at your own risk.": "Amount entered may liquidate the vault. Proceed at your own risk.",
     "Insufficient DFI and/or DUSD in vault. Add more to start minting dTokens.": "Insufficient DFI and/or DUSD in vault. Add more to start minting dTokens.",
-    "Insufficient DFI in vault. Add more to borrow DUSD.": "Insufficient DFI in vault. Add more to borrow DUSD.",
+    "Insufficient DFI or not only DUSD in vault. Add more to borrow DUSD.": "Insufficient DFI or not only DUSD in vault. Add more to borrow DUSD.",
     "Review full details in the next screen": "在下一個屏幕中查看完整詳細信息",
     "Max loan amount entered": "已輸入最高貸款金額的",
     "{{percent}} of max loan amount entered": "已輸入最高貸款金額的 {{percent}}%",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Allowing DUSD looped vaults again. Previous check for taking a new DUSD loan was to have enough DFI collateral. This will change with next hardfork to either have enough DFI in collateral, or only having DUSD as collateral.

Therefore a vault with only DUSD as its collateral must be able to take a DUSD loan. This is a MUST feature to have. It MUST be released in light-wallet before the hardfork is happening. It was already communicated like this in dev-discord.

#### Which issue(s) does this PR fixes?:

Fixes #4034 

#### Additional comments?:

- adapted translation to reflect made changes in error message. Kept in check that all previous translated pieces were translated again.
- renamed hook and file to reflect the new functionality
- added cross reference to new mn_check.cpp location where this new check is implemented on consensus level

If there are any changes missing to get in, please do them. We need to make sure to have this functionality in with next version.

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [x] Tested on Light mode and Dark mode\*
- [x] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [x] Added translations\*

<!--
* If applicable
-->
