### PR TITLE
feat(ui-ux): allow 100% dusd vault to borrow non-dusd tokens

### DIFF
--- a/mobile-app/app/screens/AppNavigator/screens/Loans/hooks/ValidateLoanAndCollateral.ts
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/hooks/ValidateLoanAndCollateral.ts
@@ -66,15 +66,12 @@ export function useValidateLoanAndCollateral(
     (col) => col.symbol === "DUSD",
   );
 
-  const isNonDUSDLoanAllowed =
-    !isTakingDUSDLoan && isDFIGreaterThanHalfOfRequiredCollateral;
-
   const isDUSDLoanAllowed =
     isTakingDUSDLoan &&
     (isDFIGreaterThanHalfOfRequiredCollateral ||
       (isFeatureAvailable("loop_dusd") && isDUSD100PercentOfCollateral));
 
   return {
-    isLoanAllowed: isNonDUSDLoanAllowed || isDUSDLoanAllowed,
+    isLoanAllowed: isDUSDLoanAllowed || !isTakingDUSDLoan,
   };
 }

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/screens/AddOrRemoveCollateralScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/screens/AddOrRemoveCollateralScreen.tsx
@@ -389,13 +389,18 @@ export function AddOrRemoveCollateralScreen({ route }: Props): JSX.Element {
         message: addOrRemoveCollateralErrors.InsufficientBalance,
       };
     } else if (
-      isFeatureAvailable("loop_dusd") &&
       hasLoan &&
-      vault.loanAmounts.some((loan) => loan.symbol === "DUSD") &&
-      vault.collateralAmounts.every((col) => col.symbol === "DUSD")
+      vault.loanAmounts.some((loan) => loan.symbol === "DUSD")
     ) {
+      const has100PercentDusdCol = vault.collateralAmounts.every(
+        (col) => col.symbol === "DUSD",
+      );
       if (
-        !["DFI", "DUSD"].includes(selectedCollateralItem.token.symbol) ||
+        (isFeatureAvailable("loop_dusd") &&
+          has100PercentDusdCol &&
+          !["DFI", "DUSD"].includes(selectedCollateralItem.token.symbol)) ||
+        (!has100PercentDusdCol &&
+          selectedCollateralItem.token.symbol === "DUSD") ||
         (selectedCollateralItem.token.symbol === "DFI" &&
           isDFILessThanHalfOfRequiredCollateral)
       ) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Allow borrowing of dTokens when vault has 100% DUSD collateral

#### To borrow **DUSD** token:
- Vault should have DFI collateral > 50% (of loan value) AND vault should NOT have any DUSD collateral
- Vault has 100% DUSD collateral (newly added when dusd-loop is enabled)

#### To borrow **non-DUSD** tokens:
- Vault should have DFI collateral > 50% of loan value
- Vault should have DUSD collateral > 50% of loan value

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
