### PR TITLE
fix(ui-ux): allow adding of dusd collateral with active dusd loan

### DIFF
--- a/mobile-app/app/screens/AppNavigator/screens/Loans/screens/AddOrRemoveCollateralScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/screens/AddOrRemoveCollateralScreen.tsx
@@ -390,25 +390,14 @@ export function AddOrRemoveCollateralScreen({ route }: Props): JSX.Element {
       };
     } else if (
       hasLoan &&
-      vault.loanAmounts.some((loan) => loan.symbol === "DUSD")
+      vault.loanAmounts.some((loan) => loan.symbol === "DUSD") &&
+      vault.collateralAmounts.every((col) => col.symbol === "DUSD") &&
+      !["DFI", "DUSD"].includes(selectedCollateralItem.token.symbol)
     ) {
-      const has100PercentDusdCol = vault.collateralAmounts.every(
-        (col) => col.symbol === "DUSD",
-      );
-      if (
-        (isFeatureAvailable("loop_dusd") &&
-          has100PercentDusdCol &&
-          !["DFI", "DUSD"].includes(selectedCollateralItem.token.symbol)) ||
-        (!has100PercentDusdCol &&
-          selectedCollateralItem.token.symbol === "DUSD") ||
-        (selectedCollateralItem.token.symbol === "DFI" &&
-          isDFILessThanHalfOfRequiredCollateral)
-      ) {
-        return {
-          testID: "full_dusd_col_affected_vault_error",
-          message: addOrRemoveCollateralErrors.DusdAffectVault,
-        };
-      }
+      return {
+        testID: "full_dusd_col_affected_vault_error",
+        message: addOrRemoveCollateralErrors.DusdAffectVault,
+      };
     }
   };
   const getRemoveCollateralErrorMessage = ():


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Allow adding of DUSD collateral to a vault with active DUSD loan

#### To borrow **DUSD** token:
- Vault should have DFI collateral > 50% (of loan value)
- Vault has 100% DUSD collateral (newly added when dusd-loop is enabled)

#### To borrow **non-DUSD** tokens:
- Vault should have DFI collateral > 50% of loan value
- Vault should have DUSD collateral > 50% of loan value

#### When adding collateral:
- Adding of DUSD collateral to a vault with both DFI and DUSD collaterals should be allowed
- Adding of non-DUSD collateral to a vault with an active DUSD loan, containing 100% DUSD collateral should not be allowed

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #4130 

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode\*
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
